### PR TITLE
Ghidra Compatibility Fixes

### DIFF
--- a/terror_player.h
+++ b/terror_player.h
@@ -561,6 +561,10 @@ struct CBasePlayer_data
 	char unknown[2344]; // 6736
 };
 
+struct CAI_ExpresserHost_data {
+	char unknown[12];
+};
+
 // From game/server/basemultiplayerplayer.h
 struct CBaseMultiplayerPlayer_data
 {
@@ -1078,7 +1082,7 @@ struct CTerrorPlayer
 	CBaseFlex_data CBaseFlex;
 	CBaseCombatCharacter_data CBaseCombatCharacter;
 	CBasePlayer_data CBasePlayer;
-	CAI_ExpresserSink_vtable * expressorsinkVtable; // 9060
+	CAI_ExpresserHost_data * CAI_ExpressorHost; // 9060
 	CBaseMultiplayerPlayer_data CBaseMultiplayerPlayer;
 	CCSPlayer_data CCSPlayer; // 9120
 	CTerrorPlayer_data CTerrorPlayer; // 10844


### PR DESCRIPTION
- Add missing struct not declared
- Define `_DWORD` and `_BYTE` if not exist

Adding these 2 fixes allows import into ghidra using "Parse C Source" using basically default options.

![Screenshot_20250601_192406](https://github.com/user-attachments/assets/9a43819f-d8ab-40a5-a4da-b9398ed3b841)

![image](https://github.com/user-attachments/assets/8a7cf1c7-e5fa-474d-a666-275c2bc43e7b)

![image](https://github.com/user-attachments/assets/d8191e11-896f-4213-84e2-1c584bb93ec0)
